### PR TITLE
Chatgpt API 테스트를 위한 test code 작성

### DIFF
--- a/ai_code_helper/.gitignore
+++ b/ai_code_helper/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/ai_code_helper/package.json
+++ b/ai_code_helper/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "apiTest" : "node test/apiTest.js"
   },
   "eslintConfig": {
     "extends": [

--- a/ai_code_helper/test/apiTest.js
+++ b/ai_code_helper/test/apiTest.js
@@ -1,0 +1,29 @@
+import { config } from "dotenv";
+// 설정 값을 가져와서
+config()
+import OpenAI from "openai"
+// chatgpt api를 사용한다.
+const apiKey = process.env.API_KEY;
+// api key를 가져옴
+const model = "text-curie-001";
+// 사용 하는 모델 지정
+console.log(apiKey);
+// key 잘 가져왔는지 확인
+const open_ai = new OpenAI({ apiKey })
+// lib 활용하는 객체 선언
+
+
+const chatCompletionsCreate = async chatPrompt => 
+// await 비동기로 API를 호출해서 gpt lib로 서버에 요청 보내서 response를 받아오는 내용
+{ const res = await open_ai.chat.completions.create({
+    messages: [ 
+        { role: "system", content: "You are good at maths." },
+        // role 지정
+    { role: "user", content: chatPrompt }, ], model: model, })
+    // 결과를 res (response) 에 저장
+    console.log("chatCompletionsCreate", res.choices)
+}
+chatCompletionsCreate("12+4");
+// 12 + 4의 결과를 가져와라
+// key billing free 
+// 


### PR DESCRIPTION
require
- .env 파일 (chatgpt api 페이지에서 api key를 받아옴, 

execution
- package.json 파일의 script 섹션을 참조하여 `npm run apiTest` 실행

ref. [gpt api js로 호출 가이드 영상](https://www.youtube.com/watch?v=4qNwoAAfnk4)